### PR TITLE
プロジェクト構成の変更とImGuiファイルの追加

### DIFF
--- a/Easing_ImGui.vcxproj
+++ b/Easing_ImGui.vcxproj
@@ -68,8 +68,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)outputs\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)outputs\$(Configuration)\MiddleBuild</IntDir>
+    <OutDir>$(ProjectDir)outputs\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)outputs\$(Configuration)\MiddleBuild</IntDir>
     <TargetName>easing</TargetName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -77,8 +77,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)outputs\$(Configuration)\</OutDir>
-    <IntDir>$(SolutionDir)outputs\$(Configuration)\MiddleBuild</IntDir>
+    <OutDir>$(ProjectDir)outputs\$(Configuration)\</OutDir>
+    <IntDir>$(ProjectDir)outputs\$(Configuration)\MiddleBuild</IntDir>
     <TargetName>easing</TargetName>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">

--- a/Easing_ImGui.vcxproj.filters
+++ b/Easing_ImGui.vcxproj.filters
@@ -27,6 +27,27 @@
     <ClCompile Include="easing\easingmanager\EasingManager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="externals\imgui\imgui.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="externals\imgui\imgui_demo.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="externals\imgui\imgui_draw.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="externals\imgui\imgui_impl_dx12.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="externals\imgui\imgui_impl_win32.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="externals\imgui\imgui_tables.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="externals\imgui\imgui_widgets.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="easing\CSVLoader.h">
@@ -39,6 +60,30 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="easing\easingmanager\EasingManager.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="externals\imgui\imconfig.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="externals\imgui\imgui.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="externals\imgui\imgui_impl_dx12.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="externals\imgui\imgui_impl_win32.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="externals\imgui\imgui_internal.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="externals\imgui\imstb_rectpack.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="externals\imgui\imstb_textedit.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="externals\imgui\imstb_truetype.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
`Easing_ImGui.vcxproj`ファイルの`OutDir`と`IntDir`のディレクトリパスが`$(SolutionDir)`から`$(ProjectDir)`に変更されました。これにより、`Debug|x64`および`Release|x64`の構成が影響を受けます。

`Easing_ImGui.vcxproj.filters`ファイルに以下のソースファイルとヘッダーファイルが追加されました:
- ソースファイル:
  - `externals\imgui\imgui.cpp`
  - `externals\imgui\imgui_demo.cpp`
  - `externals\imgui\imgui_draw.cpp`
  - `externals\imgui\imgui_impl_dx12.cpp`
  - `externals\imgui\imgui_impl_win32.cpp`
  - `externals\imgui\imgui_tables.cpp`
  - `externals\imgui\imgui_widgets.cpp`
- ヘッダーファイル:
  - `externals\imgui\imconfig.h`
  - `externals\imgui\imgui.h`
  - `externals\imgui\imgui_impl_dx12.h`
  - `externals\imgui\imgui_impl_win32.h`
  - `externals\imgui\imgui_internal.h`
  - `externals\imgui\imstb_rectpack.h`
  - `externals\imgui\imstb_textedit.h`
  - `externals\imgui\imstb_truetype.h`