### PR TITLE
ランタイムライブラリ設定を追加

### DIFF
--- a/Easing_ImGui.vcxproj
+++ b/Easing_ImGui.vcxproj
@@ -99,6 +99,7 @@
       <WarningLevel>Level3</WarningLevel>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <RuntimeLibrary>MultiThreadedDebug</RuntimeLibrary>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -125,6 +126,7 @@
       <WarningLevel>Level3</WarningLevel>
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>


### PR DESCRIPTION
`Easing_ImGui.vcxproj`ファイルにおいて、デバッグビルドでは`MultiThreadedDebug`ランタイムライブラリが使用され、リリースビルドでは`MultiThreaded`ランタイムライブラリが使用されるように`<RuntimeLibrary>`タグを追加しました。